### PR TITLE
Fix crash when for/foreach are used as hash keys

### DIFF
--- a/lib/Perl/Critic/Policy/Variables/ProhibitLoopOnHash.pm
+++ b/lib/Perl/Critic/Policy/Variables/ProhibitLoopOnHash.pm
@@ -33,6 +33,12 @@ sub violates {
     # * Then we check if it's a postfix without parenthesis
     # * Lastly, we handle the remaining cases
 
+    # skip if it is not a loop
+    # for example $var->{for}
+    unless ($elem->snext_sibling) {
+        return ();
+    }
+
     # for my $foo (%hash)
     # we simply skip the "my"
     if ( ( my $scope = $elem->snext_sibling )->isa('PPI::Token::Word') ) {

--- a/t/Variables/ProhibitLoopOnHash.run
+++ b/t/Variables/ProhibitLoopOnHash.run
@@ -61,3 +61,11 @@ print foreach (keys %{ some_big_thing() });
 for my $k (%foo ? sort keys %foo : sort keys %bar) {
 for my $k (%{$foo} ? sort keys %{$foo} : sort keys %{$bar}) {
 for my $k (%{ func() } ? sort keys %{ func() } : sort keys %{ func() }) {
+
+$hash{for}
+$hash->{for}
+$hash->{ for }
+
+$hash{foreach}
+$hash->{foreach}
+$hash->{ foreach }


### PR DESCRIPTION
Code looking like: 

```perl
$hash{for} 
$hash{foreach}
```

will cause crash:

```
Can't call method "isa" without a package or object reference at Perl/Critic/Policy/Variables/ProhibitLoopOnHash.pm line 49.
```

This fix just checks if `for/foreach` has no siblings in AST-tree. 
Not sure if it is a proper fix, i am not very familiar with `PPI::Token` and how it creates AST-tree.

Alternative solution is to check that `$elem->parent` is `PPI::Statement`, but that might potentially lead to false-positives.