### PR TITLE
don't crash when checking syntax error

### DIFF
--- a/t/Variables/ProhibitLoopOnHash.run
+++ b/t/Variables/ProhibitLoopOnHash.run
@@ -120,3 +120,8 @@ foreach \my %hash (@array_of_hash_references) {}
 ## failures 0
 ## cut
 for Class->method($foo);
+
+## name syntax error
+## failures 0
+## cut
+for my $foo @list {


### PR DESCRIPTION
When checking code with a syntax error like:

for my $foo @bar {

the check would crash.